### PR TITLE
Corrected formatting of headers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # DACExtensions
 
-##Project Description
+## Project Description
 DACExtensions contains API extensions and samples using the [DacFx API](https://msdn.microsoft.com/en-us/library/dn645454.aspx) to develop Data-Tier Applications.
 
 These extensions and samples include an improved object model, deployment contributors and static code analysis rules that can be used with Visual Studio or directly with the DacFx public API.
 
-##Background Information
+## Background Information
 SQL Server Data Tools is built into Visual Studio 2013. For other versions of visual studio you can download SQL Server Data Tools from the [Data Developer Center](https://msdn.microsoft.com/en-us/data/hh297027)
 
 SQL Server Data Tools provides an integrated environment for database developers to carry out all of their database design work for any SQL Server Platform. 
@@ -19,7 +19,7 @@ DacFx has a number of public extensibility points that customers can implement. 
 
 These samples are primarily intended to show users how to create their own extensions, test them and use them in deployment. They include solutions to real customer problems and can be used as-is if you have the same issue. Ideally you will take this project, extend it and create your own solutions.
 
-##Prerequisites
+## Prerequisites
 An installation of SQL Server Data Tools or DacFx is required to run these samples. The sample projects include references to DLLs in a Visual Studio installation with the most recent release of SQL Server Data Tools.
 
 * For Visual Studio 2013 the install directory will is "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120".
@@ -31,12 +31,12 @@ An installation of SQL Server Data Tools or DacFx is required to run these sampl
 
 This project uses Git for source code control. Visual Studio 2013 has Git support built in, and for Visual Studio 2012 please download the  Visual Studio Tools for Git plugin.
 
-##Usage
+## Usage
 The samples in this project are provided as-is. To run the samples, we recommend you download the source code and attach a debugger while running the sample console application and unit test code. 
 
 The full tutorial explaining how to use the public APIs can be found [here][dacfxturorial].
 
-##Samples Installation
+## Samples Installation
 
 These samples assume the latest SQL Server Data Tools updates for Visual Studio 2013 are installed. 
 To develop using Visual Studio 2012 please modify the .csproj files to change 
@@ -69,7 +69,7 @@ Then copy them to the extension installation directory:
 * VS 2013: %ProgramFiles(x86)%\Microsoft Visual Studio 12.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Extensions
 * VS 2012: %ProgramFiles(x86)%\Microsoft Visual Studio 11.0\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\120\Extensions
 
-##Code of Conduct
+## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 [msdn]:http://msdn.microsoft.com/en-us/library/dn268597(v=vs.103).aspx


### PR DESCRIPTION
The headers weren't rendinger correctly because of the missing space.