### PR TITLE
Stop data migrations sample

### DIFF
--- a/SampleTests/TestDeploymentStoppingContributor.cs
+++ b/SampleTests/TestDeploymentStoppingContributor.cs
@@ -95,25 +95,25 @@ namespace Public.Dac.Sample.Tests
                     AdditionalDeploymentContributors = DeploymentStoppingContributor.ContributorId
                 };
 
-                // Deploy initial schema
+                // Deploy initial schema, should pass as no data motion
                 using (DacPackage dacpac = DacPackage.Load(_dacpacPath, DacSchemaModelStorageType.Memory))
                 {
                     DacServices dacServices = new DacServices(TestUtils.ServerConnectionString);
-                    dacServices.Deploy(dacpac, dbName);
+                    dacServices.Deploy(dacpac, dbName, false, options);
                 }
 
-                // Deploy schema that will cause data motion by adding column before existing one
+                // Create schema that will cause data motion by adding column before existing one
                 using (TSqlModel model = new TSqlModel(SqlServerVersion.Sql110, null))
                 {
                     model.AddObjects("CREATE TABLE [dbo].[t1] (motion int NOT NULL, c1 INT NOT NULL PRIMARY KEY)");
                     DacPackageExtensions.BuildPackage(_dacpacPath, model, new PackageMetadata());
                 }
 
+                // Attempt to deploy and verify it fails as there's now data motion blocking it
                 using (DacPackage dacpac = DacPackage.Load(_dacpacPath, DacSchemaModelStorageType.Memory))
                 {
                     DacServices dacServices = new DacServices(TestUtils.ServerConnectionString);
 
-                    // Script then deploy, to support debugging of the generated plan
                     try
                     {
                         dacServices.GenerateDeployScript(dacpac, dbName, options);

--- a/Samples/Contributors/DeploymentStoppingContributor.cs
+++ b/Samples/Contributors/DeploymentStoppingContributor.cs
@@ -39,8 +39,8 @@ namespace Public.Dac.Samples.Contributors
     public class DeploymentStoppingContributor : DeploymentPlanModifier
     {
         public const string ContributorId = "Public.Dac.Samples.Contributors.DeploymentStoppingContributor";
-        public const string ErrorViaPublishMessage = "Canceling deployment 1!";
-        public const string ErrorViaThrownException = "Canceling deployment 2!";
+        public const string ErrorViaPublishMessage = "Data Motion Detected!";
+        public const string ErrorViaThrownException = "Data Motion Detected!";
 
         /// <summary>
         /// Iterates over the deployment plan to find the definition for 
@@ -48,11 +48,19 @@ namespace Public.Dac.Samples.Contributors
         /// <param name="context"></param>
         protected override void OnExecute(DeploymentPlanContributorContext context)
         {
-            // Publishing Severity.Error message blocks deployment
-            base.PublishMessage(new ExtensibilityError(ErrorViaPublishMessage, Severity.Error));
+            var planStep = context.PlanHandle.Head;
+            while (planStep != null)
+            {
+                if (planStep is SqlTableMigrationStep)
+                {
+                    // Publishing Severity.Error message blocks deployment
+                    base.PublishMessage(new ExtensibilityError(ErrorViaPublishMessage, Severity.Error));
 
-            // Alternatively throwing an exception will also block deployment
-            throw new DeploymentFailedException(ErrorViaThrownException);
+                    // Alternatively throwing an exception will also block deployment
+                    throw new DeploymentFailedException(ErrorViaThrownException);
+                }
+                planStep = planStep.Next;
+            }
         }
     }
 }


### PR DESCRIPTION
Improved the default "block deployment" sample by making it do something useful, namely blocking if any data migration step is detected. 